### PR TITLE
Dockerize MIST and standardize CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,11 @@ target
 
 # User-specific IntlliJ workspace:
 .idea/workspace.xml
+
+# Eclipse files
+.settings/
+.project
+.classpath
+
+# macOS files
+**/.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+FROM nvidia/cuda:9.0-runtime-ubuntu16.04
+MAINTAINER National Institute of Standards and Technology
+
+ARG EXEC_DIR="/opt/executables"
+ARG DATA_DIR="/data"
+
+# Create folders
+RUN mkdir -p ${EXEC_DIR} \
+    && mkdir -p ${EXEC_DIR}/lib/jcuda \
+    && mkdir -p ${DATA_DIR}/inputs \
+    && mkdir ${DATA_DIR}/outputs
+    
+# Install fftw and java 8 jdk
+RUN apt-get update \
+    && apt-get install -y libfftw3-dev \
+    && apt-get install -y openjdk-8-jdk \
+    && update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
+
+# Copy MIST CUDA lib
+COPY lib/jcuda/*.ptx ${EXEC_DIR}/lib/jcuda/
+
+# Copy MIST JAR
+COPY target/MIST_*-jar-with-dependencies.jar ${EXEC_DIR}/MIST.jar
+
+# Set working directory
+WORKDIR ${EXEC_DIR}
+
+# Default command. Additional arguments are provided through the command line
+ENTRYPOINT ["/usr/bin/java", "-jar", "MIST.jar"]

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>gov.nist.isg</groupId>
     <artifactId>MIST_</artifactId>
-    <version>2.0.4</version>
+    <version>2.0.5</version>
     <packaging>jar</packaging>
 
     <build>
@@ -105,6 +105,12 @@
             <artifactId>bio-formats_plugins</artifactId>
             <version>5.1.7</version>
             <scope>compile</scope>
+        </dependency>
+        
+        <dependency>
+            <groupId>commons-cli</groupId>
+            <artifactId>commons-cli</artifactId>
+            <version>1.4</version>
         </dependency>
 
     </dependencies>

--- a/src/main/java/gov/nist/isg/mist/gui/params/AdvancedParameters.java
+++ b/src/main/java/gov/nist/isg/mist/gui/params/AdvancedParameters.java
@@ -810,33 +810,37 @@ public class AdvancedParameters implements StitchingAppParamFunctions {
   }
 
 
-  public static String getParametersCommandLineHelp() {
-    String line = "\r\n";
-    String str = "********* Advanced Parameters *********";
-    str += line;
-    str += PROGRAM_TYPE + "=" + line;
-    str += NUM_CPU_THREADS + "=" + line;
-    str += LOAD_FFTW_PLAN + "=" + line;
-    str += SAVE_FFTW_PLAN + "=" + line;
-    str += FFTW_PLAN_TYPE + "=" + line;
-    str += PLAN_PATH + "=" + line;
-    str += FFTW_LIBRARY_PATH + "=" + line;
-    str += FFTW_LIBRARY_NAME + "=" + line;
-    str += FFTW_LIBRARY_FILENAME + "=" + line;
-    str += CUDA_DEVICE + "=" + line;
-    str += STAGE_REPEATABILITY + "=" + line;
-    str += HORIZONTAL_OVERLAP + "=" + line;
-    str += VERTICAL_OVERLAP + "=" + line;
-    str += NUM_FFT_PEAKS + "=" + line;
-    str += OVERLAP_UNCERTAINTY + "=" + line;
-    str += IS_USE_DOUBLE_PRECISION + "=" + line;
-    str += IS_USE_BIOFORMATS + "=" + line;
-    str += IS_SUPPRESS_MODAL_WARNING_DIALOG + "=" + line;
-    str += IS_ENABLE_CUDA_EXCEPTIONS + "=" + line;
-    str += TRANSLATION_REFINEMENT_TYPE + "=" + line;
-    str += NUM_TRANS_REFINEMENT_START_POINTS + "=" + line;
-    str += RUN_HEADLESS + "=" + line;
-    return str;
+  /**
+   * Builds the list of advanced parameter names
+   * 
+   * @return the list of advanced parameter names
+   */
+  public static List<String> getParameterNamesList() {
+  	List<String> parameterNames = new ArrayList<String>();
+  	parameterNames.add(PROGRAM_TYPE);
+  	parameterNames.add(NUM_CPU_THREADS);
+  	parameterNames.add(LOAD_FFTW_PLAN);
+  	parameterNames.add(SAVE_FFTW_PLAN);
+  	parameterNames.add(FFTW_PLAN_TYPE);
+  	parameterNames.add(PLAN_PATH);
+  	parameterNames.add(FFTW_LIBRARY_PATH);
+  	parameterNames.add(FFTW_LIBRARY_NAME);
+  	parameterNames.add(FFTW_LIBRARY_FILENAME);
+  	parameterNames.add(CUDA_DEVICE);
+  	parameterNames.add(STAGE_REPEATABILITY);
+  	parameterNames.add(HORIZONTAL_OVERLAP);
+  	parameterNames.add(VERTICAL_OVERLAP);
+  	parameterNames.add(NUM_FFT_PEAKS);
+  	parameterNames.add(OVERLAP_UNCERTAINTY);
+  	parameterNames.add(IS_USE_DOUBLE_PRECISION);
+  	parameterNames.add(IS_USE_BIOFORMATS);
+  	parameterNames.add(IS_SUPPRESS_MODAL_WARNING_DIALOG);
+  	parameterNames.add(IS_ENABLE_CUDA_EXCEPTIONS);
+  	parameterNames.add(TRANSLATION_REFINEMENT_TYPE);
+  	parameterNames.add(NUM_TRANS_REFINEMENT_START_POINTS);
+  	parameterNames.add(RUN_HEADLESS);
+    return parameterNames;
   }
+
 
 }

--- a/src/main/java/gov/nist/isg/mist/gui/params/InputParameters.java
+++ b/src/main/java/gov/nist/isg/mist/gui/params/InputParameters.java
@@ -793,28 +793,33 @@ public class InputParameters implements StitchingAppParamFunctions {
     this.globalPositionsFile = globalPositionsFile;
   }
 
-  public static String getParametersCommandLineHelp() {
-    String line = "\r\n";
-    String str = "********* Input Parameters *********";
-    str += line;
-    str += GRID_WIDTH + "=" + line;
-    str += GRID_HEIGHT + "=" + line;
-    str += START_TILE + "=" + line;
-    str += START_TILE_ROW + "=" + line;
-    str += START_TILE_COL + "=" + line;
-    str += IMAGE_DIR + "=" + line;
-    str += FILENAME_PATTERN + "=" + line;
-    str += FILENAME_PATTERN_TYPE + "=" + line;
-    str += NUMBERING_PATTERN + "=" + line;
-    str += ASSEMBLE_FROM_META + "=" + line;
-    str += START_ROW + "=" + line;
-    str += START_COL + "=" + line;
-    str += EXTENT_WIDTH + "=" + line;
-    str += EXTENT_HEIGHT + "=" + line;
-    str += TIME_SLICES + "=" + line;
-    str += IS_TIME_SLICES_ENABLED + "=" + line;
-    str += GLOBAL_POSITIONS_FILE + "=" + line;
-    return str;
-  }
+  
+  /**
+   * Builds the list of input parameter names
+   * 
+   * @return the list of input parameter names
+   */
+  public static List<String> getParameterNamesList() {
+	  	List<String> parameterNames = new ArrayList<String>();
+	  	parameterNames.add(GRID_WIDTH);
+	  	parameterNames.add(GRID_HEIGHT);
+	  	parameterNames.add(START_TILE);
+	  	parameterNames.add(START_TILE_ROW);
+	  	parameterNames.add(START_TILE_COL);
+	  	parameterNames.add(IMAGE_DIR);
+	  	parameterNames.add(FILENAME_PATTERN);
+	  	parameterNames.add(FILENAME_PATTERN_TYPE);
+	  	parameterNames.add(GRID_ORIGIN);
+	  	parameterNames.add(NUMBERING_PATTERN);
+	  	parameterNames.add(ASSEMBLE_FROM_META);
+	  	parameterNames.add(START_ROW);
+	  	parameterNames.add(START_COL);
+	  	parameterNames.add(EXTENT_WIDTH);
+	  	parameterNames.add(EXTENT_HEIGHT);
+	  	parameterNames.add(TIME_SLICES);
+	  	parameterNames.add(IS_TIME_SLICES_ENABLED);
+	  	parameterNames.add(GLOBAL_POSITIONS_FILE);
+	    return parameterNames;
+	  }
 
 }

--- a/src/main/java/gov/nist/isg/mist/gui/params/LoggingParameters.java
+++ b/src/main/java/gov/nist/isg/mist/gui/params/LoggingParameters.java
@@ -21,6 +21,8 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.prefs.Preferences;
 
 import gov.nist.isg.mist.gui.params.interfaces.StitchingAppParamFunctions;
@@ -199,15 +201,17 @@ public class LoggingParameters implements StitchingAppParamFunctions {
     this.debugLevel = debugLevel;
   }
 
-
-  public static String getParametersCommandLineHelp() {
-    String line = "\r\n";
-    String str = "********* Logging Parameters *********";
-    str += line;
-    str += LOG_LEVEL + "=" + line;
-    str += DEBUG_LEVEL + "=" + line;
-    return str;
+  
+  /**
+   * Builds the list of logging parameter names
+   * 
+   * @return the list of logging parameter names
+   */
+  public static List<String> getParameterNamesList() {
+  	List<String> parameterNames = new ArrayList<String>();
+  	parameterNames.add(LOG_LEVEL);
+  	parameterNames.add(DEBUG_LEVEL);
+    return parameterNames;
   }
-
 
 }

--- a/src/main/java/gov/nist/isg/mist/gui/params/OutputParameters.java
+++ b/src/main/java/gov/nist/isg/mist/gui/params/OutputParameters.java
@@ -21,6 +21,8 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.prefs.Preferences;
 
 import gov.nist.isg.mist.gui.params.interfaces.StitchingAppParamFunctions;
@@ -502,20 +504,22 @@ public class OutputParameters implements StitchingAppParamFunctions {
   }
 
 
-  public static String getParametersCommandLineHelp() {
-    String line = "\r\n";
-    String str = "********* Output Parameters *********";
-    str += line;
-    str += OUTPUT_PATH + "=" + line;
-    str += DISPLAY_STITCHING + "=" + line;
-    str += OUTPUT_FULL_IMAGE + "=" + line;
-    str += OUTPUT_META + "=" + line;
-    str += OUTPUT_IMG_PYRAMID + "=" + line;
-    str += OUT_FILE_PREFIX + "=" + line;
-    str += BLENDING_MODE + "=" + line;
-    str += BLENDING_ALPHA + "=" + line;
-    return str;
+  /**
+   * Builds the list of output parameter names
+   * 
+   * @return the list of output parameter names
+   */
+  public static List<String> getParameterNamesList() {
+  	List<String> parameterNames = new ArrayList<String>();
+  	parameterNames.add(OUTPUT_PATH);
+  	parameterNames.add(DISPLAY_STITCHING);
+  	parameterNames.add(OUTPUT_FULL_IMAGE);
+  	parameterNames.add(OUTPUT_META);
+  	parameterNames.add(OUTPUT_IMG_PYRAMID);
+  	parameterNames.add(OUT_FILE_PREFIX);
+  	parameterNames.add(BLENDING_MODE);
+  	parameterNames.add(BLENDING_ALPHA);
+    return parameterNames;
   }
-
 
 }

--- a/src/main/java/gov/nist/isg/mist/lib/imagetile/jcuda/CudaImageTile.java
+++ b/src/main/java/gov/nist/isg/mist/lib/imagetile/jcuda/CudaImageTile.java
@@ -253,10 +253,9 @@ public class CudaImageTile extends ImageTile<CUdeviceptr> {
 
 
     String fijiDir = IJ.getDirectory("imagej");
-    if(fijiDir == null)
+    if(fijiDir == null || fijiDir.equals("null/"))
       fijiDir = "";
 
-    System.out.println("Hello world");
     Log.msg(LogType.MANDATORY, CUDA_MODULE_NAME);
     File testFile = new File(fijiDir + CUDA_MODULE_NAME);
 

--- a/src/main/java/gov/nist/isg/mist/lib32/imagetile/jcuda/CudaImageTile32.java
+++ b/src/main/java/gov/nist/isg/mist/lib32/imagetile/jcuda/CudaImageTile32.java
@@ -251,7 +251,7 @@ public class CudaImageTile32 extends ImageTile<CUdeviceptr> {
       throws IOException {
 
     String fijiDir = IJ.getDirectory("imagej");
-    if(fijiDir == null)
+    if(fijiDir == null || fijiDir.equals("null/"))
       fijiDir = "";
 
     File testFile = new File(fijiDir + CUDA_MODULE_NAME);


### PR DESCRIPTION
The following changes have been implemented:
- change command line arguments parsing for standalone JAR to use standard command line options (using Apache Commons CLI)
- add Dockerfile (a new repo has been created in the DockerHub for MIST in the WIPP org https://hub.docker.com/r/wipp/mist)
- fix CUDA module path when running as standalone JAR
- bump version number to 2.0.5

These changes have been made to facilitate the integration with the WIPP system.